### PR TITLE
AuthCodeFlow simplified usage

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -91,22 +91,17 @@ class GoogleButton extends Control
 		$this->flow = $flow;
 	}
 
-	public function authenticate(): void
+	public function authenticate(string $authorizationUrl): void
 	{
-		$this->flow->getProvider()->setRedirectUri(
-			$this->presenter->link('//:Sign:googleAuthorize')
+		$this->presenter->redirectUrl(
+		  $this->flow->getAuthorizationUrl($authorizationUrl)
 		);
-		$this->presenter->redirectUrl($this->flow->getAuthorizationUrl());
 	}
 
-	public function authorize(array $parameters): void
+	public function authorize(array $parameters = null): void
 	{
-		// Setup propel redirect URL
-		$this->flow->getProvider()->setRedirectUri(
-			$this->presenter->link('//:Sign:googleAuthorize')
-		);
-
 		try {
+			$parameters = $parameters ?? $this->getPresenter()->getHttpRequest()->getQuery();
 			$accessToken = $this->flow->getAccessToken($parameters);
 		} catch (IdentityProviderException $e) {
 			// TODO - Identity provider failure, cannot get information about user
@@ -125,23 +120,27 @@ Add control to sign presenter
 
 ```php
 use Nette\Application\UI\Presenter;
+use Contributte\OAuth2Client\Flow\Google\GoogleAuthCodeFlow;
 
 class SignPresenter extends Presenter
 {
 
+	/** @inject */
+	public GoogleAuthCodeFlow $googleAuthCodeFlow;
+
 	public function actionGoogleAuthenticate(): void
 	{
-		$this['googleButton']->authenticate();
+		$this['googleButton']->authenticate($this->presenter->link('//:Sign:googleAuthorize'));
 	}
 
 	public function actionGoogleAuthorize(): void
 	{
-		$this['googleButton']->authorize($this->getHttpRequest()->getQuery());
+		$this['googleButton']->authorize();
 	}
 
 	protected function createComponentGoogleButton(): GoogleButton
 	{
-		// TODO - create and return GoogleButton control
+		return new GoogleButton($this->googleAuthCodeFlow);
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "extra": {
     "branch-alias": {

--- a/src/Flow/AuthCodeFlow.php
+++ b/src/Flow/AuthCodeFlow.php
@@ -4,6 +4,7 @@ namespace Contributte\OAuth2Client\Flow;
 
 use Contributte\OAuth2Client\Exception\Logical\InvalidArgumentException;
 use Contributte\OAuth2Client\Exception\Runtime\PossibleCsrfAttackException;
+use Contributte\OAuth2Client\Exception\RuntimeException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
@@ -28,15 +29,25 @@ abstract class AuthCodeFlow
 	}
 
 	/**
+	 * @param string|mixed[]|null $redirectUriOrOptions
 	 * @param mixed[] $options
 	 */
-	public function getAuthorizationUrl(array $options = []): string
+	public function getAuthorizationUrl($redirectUriOrOptions = null, array $options = []): string
 	{
+		if (is_array($redirectUriOrOptions)) {
+			$options = array_merge($options, $redirectUriOrOptions);
+		} elseif (is_string($redirectUriOrOptions)) {
+			$options['redirect_uri'] = $redirectUriOrOptions;
+		} elseif ($redirectUriOrOptions !== null) { /** @phpstan-ignore-line */
+			throw new RuntimeException('Parameter #1 redirectUriOrOptions of getAuthorizationUrl accepts only string or array.');
+		}
+
 		$session = $this->session->getSection(self::SESSION_NAMESPACE);
 
 		$url = $this->provider->getAuthorizationUrl($options);
 
 		$session['state'] = $this->provider->getState();
+		$session['redirect_uri'] = $options['redirect_uri'] ?? null;
 
 		return $url;
 	}
@@ -46,7 +57,7 @@ abstract class AuthCodeFlow
 	 * @return AccessToken|AccessTokenInterface
 	 * @throws IdentityProviderException
 	 */
-	public function getAccessToken(array $parameters): AccessTokenInterface
+	public function getAccessToken(array $parameters, ?string $redirectUri = null): AccessTokenInterface
 	{
 		if (!isset($parameters['code'])) {
 			throw new InvalidArgumentException('Missing "code" parameter');
@@ -61,12 +72,17 @@ abstract class AuthCodeFlow
 		// Possible CSRF attack
 		if (isset($session['state']) && $parameters['state'] !== $session['state']) {
 			unset($session['state']);
-
+			unset($session['redirect_uri']);
 			throw new PossibleCsrfAttackException();
 		}
 
+		$options = array_filter([
+			'code' => $parameters['code'],
+			'redirect_uri' => $redirectUri ?? $session['redirect_uri'] ?? null,
+		]);
+
 		// Try to get an access token (using the authorization code grant)
-		return $this->provider->getAccessToken('authorization_code', ['code' => $parameters['code']]);
+		return $this->provider->getAccessToken('authorization_code', $options);
 	}
 
 	public function getProvider(): AbstractProvider

--- a/src/Flow/Google/GoogleAuthCodeFlow.php
+++ b/src/Flow/Google/GoogleAuthCodeFlow.php
@@ -21,13 +21,13 @@ class GoogleAuthCodeFlow extends AuthCodeFlow
 	/**
 	 * @inheritdoc
 	 */
-	public function getAccessToken(array $parameters): AccessTokenInterface
+	public function getAccessToken(array $parameters, ?string $redirectUri = null): AccessTokenInterface
 	{
 		if (isset($parameters['error'])) {
 			throw new UserProbablyDeniedAccessException($parameters['error']);
 		}
 
-		return parent::getAccessToken($parameters);
+		return parent::getAccessToken($parameters, $redirectUri);
 	}
 
 }

--- a/tests/cases/Flow/Facebook/FacebookAuthCodeFlowTest.integration.phpt
+++ b/tests/cases/Flow/Facebook/FacebookAuthCodeFlowTest.integration.phpt
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Flow;
+
+use Contributte\OAuth2Client\Flow\Facebook\FacebookAuthCodeFlow;
+use Contributte\OAuth2Client\Flow\Facebook\FacebookProvider;
+use Mockery;
+use Nette\Http\Session;
+use Nette\Http\SessionSection;
+use Ninjify\Nunjuck\Toolkit;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$provider = new FacebookProvider([
+		'clientId' => 'foo',
+		'clientSecret' => 'bar',
+		'graphApiVersion' => 'v3.2',
+	]);
+
+	$sessionSection = Mockery::mock(SessionSection::class);
+	$sessionSection->shouldReceive('offsetSet');
+
+	$session = Mockery::mock(Session::class);
+	$session->shouldReceive('getSection')
+		->andReturn($sessionSection);
+
+	$flow = new FacebookAuthCodeFlow($provider, $session);
+
+	Assert::same(
+		'https://www.facebook.com/v3.2/dialog/oauth?state=myState&redirect_uri=https%3A%2F%2Flocalhost%2Fredirect_uri' .
+		'&scope=public_profile%2Cemail&response_type=code&approval_prompt=auto&client_id=foo',
+		$flow->getAuthorizationUrl('https://localhost/redirect_uri', ['state' => 'myState'])
+	);
+});

--- a/tests/cases/Flow/Google/GoogleAuthCodeFlowTest.integration.phpt
+++ b/tests/cases/Flow/Google/GoogleAuthCodeFlowTest.integration.phpt
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Cases\Flow;
+
+use Contributte\OAuth2Client\Flow\Google\GoogleAuthCodeFlow;
+use Contributte\OAuth2Client\Flow\Google\GoogleProvider;
+use Mockery;
+use Nette\Http\Session;
+use Nette\Http\SessionSection;
+use Ninjify\Nunjuck\Toolkit;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+Toolkit::test(function (): void {
+	$provider = new GoogleProvider([
+		'clientId' => 'foo',
+		'clientSecret' => 'bar',
+	]);
+
+	$sessionSection = Mockery::mock(SessionSection::class);
+	$sessionSection->shouldReceive('offsetSet');
+
+	$session = Mockery::mock(Session::class);
+	$session->shouldReceive('getSection')
+		->andReturn($sessionSection);
+
+	$flow = new GoogleAuthCodeFlow($provider, $session);
+
+	Assert::same(
+		'https://accounts.google.com/o/oauth2/v2/auth?state=myState&redirect_uri=https%3A%2F%2Flocalhost%2Fredirect_uri' .
+		'&scope=openid%20email%20profile&response_type=code&client_id=foo',
+		$flow->getAuthorizationUrl('https://localhost/redirect_uri', ['state' => 'myState'])
+	);
+});


### PR DESCRIPTION
- passing redirect_uri as parameter instead modifying settings in Provider
- BC optional simplified passing to `getAuthorizationUrl` and `getAccessToken`
- `redirect_uri` could be remembered in session alongside with `state` so it is not required to pass it to `getAccessToken`
- added unit tests and basic integration tests with `league/oauth2-client` providers